### PR TITLE
Fix several issues stopping library from working

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ var Schematic = require('minecraft-schematic');
 
 var data = fs.readFileSync('./myawesomehouse.schematic');
 
-Schematic.loadSchematic(data, function(build) {
-    build.getWidth()    // 10
-	build.getLength()   // 12
-	build.getHeight()   // 8
-	build.getBlockID(0, 0, 0) // 1
-	build.getBlockMeta(0, 0, 0) // 0
+Schematic.loadSchematic(data, function(error, build) {
+	    if (error) throw error;
+	build.getWidth();    // 10
+	build.getLength();   // 12
+	build.getHeight();   // 8
+	build.getBlockID(0, 0, 0); // 1
+	build.getBlockMeta(0, 0, 0); // 0
 	build.setBlockID(3, 3, 3, 5);
 	build.setBlockMeta(3, 3, 3, 2);
 });

--- a/src/schematic.js
+++ b/src/schematic.js
@@ -88,7 +88,7 @@ class Schematic {
                 this.blockMeta = tag.value.value.Data.value;
             }).call(s);
 
-            cb(s);
+            cb(undefined, s);
         });
     };
 }

--- a/src/schematic.js
+++ b/src/schematic.js
@@ -77,18 +77,18 @@ class Schematic {
                 return;
             }
 
-            var length = tag.Schematic.Length;
-            var width  = tag.Schematic.Width;
-            var height = tag.Schematic.Height;
+            var length = tag.value.value.Length.value;
+            var width = tag.value.value.Width.value;
+            var height = tag.value.value.Height.value;
 
             var s = new Schematic(length, width, height);
 
             (function() {
-                this.blockData = tag.Schematic.Blocks;
-                this.blockMeta = tag.Schematic.Data;
+                this.blockData = tag.value.value.Blocks.value;
+                this.blockMeta = tag.value.value.Data.value;
             }).call(s);
 
-            cb(undefined, s);
+            cb(s);
         });
     };
 }


### PR DESCRIPTION
Fixed issues probably relating to a new version of prismarine-nbt (must use a different way of getting length, width, height, block data, and block meta now)
Removed undefined parameter when calling the callback function in loadSchematic as the documentation in the README shows it not being there and it seems to serve no purpose
