### PR TITLE
TypeError bug fix and Buffer.alloc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minecraft-schematic",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Read and write Minecraft schematic files",
   "main": "index.js",
   "scripts": {

--- a/src/schematic.js
+++ b/src/schematic.js
@@ -6,10 +6,9 @@ var nbt = require('prismarine-nbt');
 class Schematic {
 
     constructor(x, y, z) {
-        this.blockData = new Buffer(x * y * z);
-        this.blockData.fill(0);
-        this.blockMeta = new Buffer(x * y * z);
-        this.blockMeta.fill(0);
+        // Buffer will be filled with 0 (by default)
+        this.blockData = Buffer.alloc(x * y * z);
+        this.blockMeta = Buffer.alloc(x * y * z);
 
         this.length = x;
         this.width  = z;

--- a/src/schematic.js
+++ b/src/schematic.js
@@ -77,15 +77,15 @@ class Schematic {
                 return;
             }
 
-            var length = tag.value.value.Length.value;
-            var width = tag.value.value.Width.value;
-            var height = tag.value.value.Height.value;
+            var length = tag.value.Length.value;
+            var width = tag.value.Width.value;
+            var height = tag.value.Height.value;
 
             var s = new Schematic(length, width, height);
 
             (function() {
-                this.blockData = tag.value.value.Blocks.value;
-                this.blockMeta = tag.value.value.Data.value;
+                this.blockData = tag.value.Blocks.value;
+                this.blockMeta = tag.value.Data.value;
             }).call(s);
 
             cb(undefined, s);


### PR DESCRIPTION
```
                this.blockData = tag.value.value.Blocks.value;
                                                 ^

TypeError: Cannot read property 'Blocks' of undefined
    at Schematic.<anonymous> (/home/user/Minecraft/Arts/minecraft-schematic/src/schematic.js:91:50)
    at /home/user/Minecraft/Arts/minecraft-schematic/src/schematic.js:93:16
    at Gunzip.cb (/home/user/node_modules/prismarine-nbt/nbt.js:45:9)
    at Gunzip.zlibBufferOnEnd (zlib.js:149:10)
    at Gunzip.emit (events.js:323:22)
    at endReadableNT (_stream_readable.js:1204:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

`(node:3750) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`